### PR TITLE
Allow overriding path to server executable

### DIFF
--- a/src/ts/MacKeyServer.ts
+++ b/src/ts/MacKeyServer.ts
@@ -35,9 +35,9 @@ export class MacKeyServer implements IGlobalKeyServer {
     public start(skipPerms?: boolean): Promise<void> {
         this.running = true;
 
-        const path = Path.join(__dirname, sPath);
+        const serverPath = this.config.serverPath || Path.join(__dirname, sPath);
 
-        this.proc = spawn(path);
+        this.proc = spawn(serverPath);
         if (this.config.onInfo)
             this.proc.stderr.on("data", data => this.config.onInfo?.(data.toString()));
         const onError = this.config.onError;
@@ -65,6 +65,7 @@ export class MacKeyServer implements IGlobalKeyServer {
     protected handleStartup(skipPerms: boolean): Promise<void> {
         return new Promise<void>((res, rej) => {
             let errored = false;
+            const serverPath = this.config.serverPath || Path.join(__dirname, sPath);
 
             // If setup fails, try adding permissions
             this.proc.on("error", async err => {
@@ -75,7 +76,7 @@ export class MacKeyServer implements IGlobalKeyServer {
                     try {
                         this.restarting = true;
                         this.proc.kill();
-                        await this.addPerms(Path.join(__dirname, sPath));
+                        await this.addPerms(serverPath);
 
                         // If the server was stopped in between, just act as if it was started successfully
                         if (!this.running) {

--- a/src/ts/WinKeyServer.ts
+++ b/src/ts/WinKeyServer.ts
@@ -27,7 +27,8 @@ export class WinKeyServer implements IGlobalKeyServer {
 
     /** Start the Key server and listen for keypresses */
     public async start() {
-        this.proc = execFile(Path.join(__dirname, sPath), { maxBuffer: Infinity });
+        const serverPath = this.config.serverPath || Path.join(__dirname, sPath);
+        this.proc = execFile(serverPath, { maxBuffer: Infinity });
         if (this.config.onInfo)
             this.proc.stderr?.on("data", data => this.config.onInfo?.(data.toString()));
         if (this.config.onError) this.proc.on("close", this.config.onError);

--- a/src/ts/_types/IMacConfig.ts
+++ b/src/ts/_types/IMacConfig.ts
@@ -4,4 +4,6 @@ export type IMacConfig = {
     onInfo?: {(data: string): void};
     /** A callback that's triggered with additional information from the keyhandler */
     onError?: {(errorCode: number | null): void};
+    /** Path to server executable */
+    serverPath?: string
 };

--- a/src/ts/_types/IWindowsConfig.ts
+++ b/src/ts/_types/IWindowsConfig.ts
@@ -4,4 +4,6 @@ export type IWindowsConfig = {
     onInfo?: { (data: string): void }
     /** A callback that's triggered with additional information from the keyhandler */
     onError?: { (errorCode: number): void }
+    /** Path to server executable */
+    serverPath?: string
 };


### PR DESCRIPTION
Intended as a workaround for issue #18 such that the path to the server executable can be manually overridden in production. If no serverPath is included with config defaults to original path.