### PR TITLE
Fix event types (do not pretend we have all possibly key codes handled)

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -16,7 +16,7 @@ v.addListener(function (e, down) {
             " " +
             (e.state == "DOWN" ? "DOWN" : "UP  ") +
             "       [" +
-            e.rawKey._nameRaw +
+            e.rawKey?._nameRaw +
             "]"
     );
 

--- a/src/ts/_types/IGlobalKeyEvent.ts
+++ b/src/ts/_types/IGlobalKeyEvent.ts
@@ -5,7 +5,7 @@ import {IGlobalKey} from "./IGlobalKey";
  */
 export type IGlobalKeyEvent = {
     vKey: number;
-    rawKey: {
+    rawKey?: {
         _nameRaw: string;
         name: string;
     };

--- a/src/ts/_types/IGlobalKeyLookup.ts
+++ b/src/ts/_types/IGlobalKeyLookup.ts
@@ -1,5 +1,5 @@
 import {IGlobalKey} from "./IGlobalKey";
 
 export type IGlobalKeyLookup = {
-    [key: number]: {_nameRaw: string; name: string; standardName?: IGlobalKey};
+    [key: number]: undefined | {_nameRaw: string; name: string; standardName?: IGlobalKey};
 };


### PR DESCRIPTION
There is little chance we have all possible key code definitions hardcoded in `src/ts/_data/*GlobalKeyLookup.ts` files, and even if we had, operating systems can update to include new key codes.

This is why `IGlobalKeyEvent.rawKey` has to be optional, for some keys we can only supply the `scanCode` and nothing more.