### PR TITLE
Hide executable window

### DIFF
--- a/src/ts/WinKeyServer.ts
+++ b/src/ts/WinKeyServer.ts
@@ -28,7 +28,7 @@ export class WinKeyServer implements IGlobalKeyServer {
     /** Start the Key server and listen for keypresses */
     public async start() {
         const serverPath = this.config.serverPath || Path.join(__dirname, sPath);
-        this.proc = execFile(serverPath, { maxBuffer: Infinity });
+        this.proc = execFile(serverPath, { maxBuffer: Infinity, windowsHide: true });
         if (this.config.onInfo)
             this.proc.stderr?.on("data", data => this.config.onInfo?.(data.toString()));
         if (this.config.onError) this.proc.on("close", this.config.onError);


### PR DESCRIPTION
Hi! I automated the launch of my process with pm2 and it opens a window. I use this to detect key combinations when playing games and sometimes, if my program crashes, it restarts showing the black window in the middle of the screen (a big problem in my case because I use a wheel, not a mouse/keyboard, so I cannot close it).
This change works and makes the library safer :) 
Thanks for your work!